### PR TITLE
ecj.jar issue happening in the new version of processing

### DIFF
--- a/src/processing/mode/android/AndroidBuild.java
+++ b/src/processing/mode/android/AndroidBuild.java
@@ -627,7 +627,7 @@ class AndroidBuild extends JavaBuild {
     writer.println("       <isset property=\"env.ANDROID_HOME\" />");
     writer.println("  </condition>");
 
-    writer.println("  <property name=\"ecj.jar\" value=\"" + Base.getToolsFolder() + "/../modes/Java/mode/ecj.jar\" />");
+    writer.println("  <property name=\"ecj.jar\" value=\"" + Base.getToolsFolder() + "/../modes/java/mode/ecj.jar\" />");
     writer.println("  <property name=\"build.compiler\" value=\"org.eclipse.jdt.core.JDTCompilerAdapter\" />");
 
     writer.println("  <mkdir dir=\"bin\" />");


### PR DESCRIPTION
In the new version of processing, as I think, the location of ecj.jar has probably been changed.
This commit fixes the issue : https://github.com/processing/processing-android/issues/67

Signed-off-by: Umair Khan omerjerk@gmail.com
