### PR TITLE
saveFrame - save file in gallery(sdcard) instead of /data

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -5289,10 +5289,17 @@ public class PApplet extends Activity implements PConstants, Runnable {
   }
 
   public File getSDCardDirectoryFile(String where) {
-	  return new File(new File(
-			  Environment.getExternalStorageDirectory() + "/Processing",
-			  getPackageName()),
-			  where);
+	  String state = Environment.getExternalStorageState();
+	  if (Environment.MEDIA_MOUNTED.equals(state)) {
+		  return new File(new File(
+				  Environment.getExternalStorageDirectory() + "/Processing",
+				  getPackageName()),
+				  where);
+	  } else {
+		  //If external storage is not available, fall back to internal storage.
+		  Log.i(getComponentName().getPackageName(), "External storage not available, falling back to internal.");
+		  return new File(sketchPath(where));
+	  }
   }
 
   /**

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -38,9 +38,11 @@ import android.content.pm.ConfigurationInfo;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.graphics.*;
+import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.opengl.GLSurfaceView;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
 import android.text.format.Time;
 import android.util.*;
@@ -5286,6 +5288,12 @@ public class PApplet extends Activity implements PConstants, Runnable {
     return new File(sketchPath(where));
   }
 
+  public File getSDCardDirectoryFile(String where) {
+	  return new File(new File(
+			  Environment.getExternalStorageDirectory() + "/Processing",
+			  getPackageName()),
+			  where);
+  }
 
   /**
    * Returns a path inside the applet folder to save to. Like sketchPath(),
@@ -5302,11 +5310,12 @@ public class PApplet extends Activity implements PConstants, Runnable {
    */
   public String savePath(String where) {
     if (where == null) return null;
-//    System.out.println("filename before sketchpath is " + where);
-    String filename = sketchPath(where);
-//    System.out.println("filename after sketchpath is " + filename);
+    File filename = getSDCardDirectoryFile(where);
     createPath(filename);
-    return filename;
+    //Notify the Gallery fot the new file
+    MediaScannerConnection.scanFile(this,
+    		new String[] { filename.getPath() }, new String[] { "image/*" }, null);
+    return filename.getAbsolutePath();
   }
 
 


### PR DESCRIPTION
Prior to this commit, saveFile() was saving data in /data partition. Saving something to this location is trivial to the end user. 
Instead, we should save the image in sdcard and update the same in Gallery.

Signed-off-by: Umair Khan <omerjerk@gmail.com>