### PR TITLE
Bugfix preprocessor

### DIFF
--- a/src/processing/mode/android/AndroidPreprocessor.java
+++ b/src/processing/mode/android/AndroidPreprocessor.java
@@ -63,7 +63,9 @@ public class AndroidPreprocessor extends PdePreprocessor {
     sizeStatement = info[0];
     sketchWidth = info[1];
     sketchHeight = info[2];
-    sketchRenderer = info[3];
+    if (info[3] != null) {
+    	sketchRenderer = info[3].replace(",", "");
+    }
     return info;
   }
   


### PR DESCRIPTION
Calling the `size()` function in the following manner causes a compilation error :
    `size(640,360 , P3D);`
i.e. adding an extra space after 360 is causing the problem.

This pull request fixes the mentioned issue.
