### PR TITLE
Processing keeps waiting for devices for infinite time

### DIFF
--- a/src/processing/mode/android/AndroidRunner.java
+++ b/src/processing/mode/android/AndroidRunner.java
@@ -55,7 +55,7 @@ public class AndroidRunner implements DeviceListener {
 //  final Device device = waitForDevice(deviceFuture, monitor);
     final Device device = waitForDevice(deviceFuture, listener);
     if (device == null || !device.isAlive()) {
-      listener.statusError("Lost connection with device while launching. Try again.");
+      listener.statusError("Couldn't find the device. Try again.");
       // Reset the server, in case that's the problem. Sometimes when 
       // launching the emulator times out, the device list refuses to update.
       Devices.killAdbServer();

--- a/src/processing/mode/android/Devices.java
+++ b/src/processing/mode/android/Devices.java
@@ -199,9 +199,11 @@ class Devices {
     if (hardware != null) {
       return hardware;
     }
+    int sleepCount = 0;
     while (!Thread.currentThread().isInterrupted()) {
       try {
         Thread.sleep(2000);
+        ++sleepCount;
       } catch (final InterruptedException e) {
         return null;
       }
@@ -209,6 +211,7 @@ class Devices {
       if (hardware != null) {
         return hardware;
       }
+      if (sleepCount > 4) break; //We won't wait for more than 10 seconds
     }
     return null;
   }


### PR DESCRIPTION
If no device is connected, Processing keeps waiting for the devices to connect for infinite time.
Waiting for 10 seconds is sufficient and beyond that we should notify the user that a device couldn't be found.

Signed-off-by: Umair Khan omerjerk@gmail.com
