### PR TITLE
Absolute path for android-core.zip

### DIFF
--- a/src/processing/mode/android/AndroidMode.java
+++ b/src/processing/mode/android/AndroidMode.java
@@ -22,6 +22,7 @@
 package processing.mode.android;
 
 import processing.app.Base;
+import processing.app.Preferences;
 import processing.app.Library;
 import processing.app.Messages;
 import processing.app.Platform;
@@ -108,7 +109,10 @@ public class AndroidMode extends JavaMode {
 
       // otherwise do the usual
       //    return new File(base.getSketchbookFolder(), ANDROID_CORE_FILENAME);
-      coreZipLocation = getContentFile("android-core.zip");
+      // coreZipLocation = getContentFile("android-core.zip");
+      coreZipLocation = new File(Preferences.getSketchbookPath()
+                                    + "/modes/AndroidMode/android-core.zip");
+
     }
     return coreZipLocation;
   }


### PR DESCRIPTION
Changing the relative path to an absolute path for android-core.zip file location retrieval. NOTE: this tastes more like a hack than a fix - the root problem was that the commandline build script couldn't find any of the needed files - maybe Processing knows how to tell these paths to the build script somehow? This change needs testing on various platforms (works on Linux Mint 17 64). 

Tastes like a hack because I'm changing a hardcoded value to an even more hardcoded value.