### PR TITLE
Android target upgrade from 10 to 15

### DIFF
--- a/src/processing/mode/android/AndroidBuild.java
+++ b/src/processing/mode/android/AndroidBuild.java
@@ -47,8 +47,8 @@ import java.security.Permission;
 class AndroidBuild extends JavaBuild {
   //  static final String basePackage = "changethispackage.beforesubmitting.tothemarket";
   static final String basePackage = "processing.test";
-  static String sdkName = "2.3.3";
-  static String sdkVersion = "10";  // Android 2.3.3 (Gingerbread)
+  static String sdkName = "4.0.3";
+  static String sdkVersion = "15";  // Android 4.0.3 (Ice Cream Sandwich MR1)
   static String sdkTarget = "android-" + sdkVersion;
 
   private final AndroidSDK sdk;


### PR DESCRIPTION
Upgrade of the build target version number from 10 to 15 to get commandline build working again. I further suggest moving these values to an external settings file that could also hold major file locations as well.