### PR TITLE
don't check for sdk inside the constructor of AndroidMode

### DIFF
--- a/src/processing/mode/android/AndroidMode.java
+++ b/src/processing/mode/android/AndroidMode.java
@@ -47,7 +47,6 @@ public class AndroidMode extends JavaMode {
 
   public AndroidMode(Base base, File folder) {
     super(base, folder);
-    checkSDK(null);
   }
 
 

--- a/src/processing/mode/android/AndroidMode.java
+++ b/src/processing/mode/android/AndroidMode.java
@@ -130,13 +130,13 @@ public class AndroidMode extends JavaMode {
     }
   }
 
-  public void checkSDK(Editor parent) {
+  public void checkSDK(Editor editor) {
     if (sdk == null) {
       try {
         sdk = AndroidSDK.load();
         // FIXME REVERT THIS STATEMENT AFTER TESTING (should be ==)
-        if (sdk == null && parent != null) {
-          sdk = AndroidSDK.locate(parent, this);
+        if (sdk == null && editor != null) {
+          sdk = AndroidSDK.locate(editor, this);
         }
       } catch (BadSDKException e) {
         e.printStackTrace();


### PR DESCRIPTION
This check again happens inside the contructor of AndroidEditor class
which also ensures that editor will never be null.

Signed-off-by: Umair Khan <omerjerk@gmail.com>