### PR TITLE
PApplet does not extends anything now same as java mode.

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -59,7 +59,7 @@ import processing.event.*;
 import processing.opengl.*;
 
 
-public class PApplet extends Fragment implements PConstants, Runnable {
+public class PApplet implements PConstants, Runnable {
 
   /**
    * The activity which holds this fragment.
@@ -445,13 +445,11 @@ public class PApplet extends Fragment implements PConstants, Runnable {
 
   /** Called with the activity is first created. */
   @SuppressWarnings("unchecked")
-  @Override
-  public View onCreateView(LayoutInflater inflater, ViewGroup container,
-      Bundle savedInstanceState) {
+  public View onCreateView(Activity activity) {
 
     if (DEBUG) println("onCreateView() happening here: " + Thread.currentThread().getName());
 
-    activity = getActivity();
+    this.activity = activity;
     View rootView;
 
     DisplayMetrics dm = new DisplayMetrics();
@@ -627,16 +625,9 @@ public class PApplet extends Fragment implements PConstants, Runnable {
   }
 
 
-  @Override
-  public void onConfigurationChanged(Configuration newConfig) {
-    if (DEBUG) System.out.println("configuration changed: " + newConfig);
-    super.onConfigurationChanged(newConfig);
-  }
+  
 
-
-  @Override
   public void onResume() {
-    super.onResume();
 
     // TODO need to bring back app state here!
 //    surfaceView.onResume();
@@ -649,9 +640,7 @@ public class PApplet extends Fragment implements PConstants, Runnable {
   }
 
 
-  @Override
   public void onPause() {
-    super.onPause();
 
     // TODO need to save all application state here!
 //    System.out.println("PApplet.onPause() called");
@@ -716,14 +705,12 @@ public class PApplet extends Fragment implements PConstants, Runnable {
   }
 
 
-  @Override
   public void onDestroy() {
 //    stop();
     dispose();
     if (PApplet.DEBUG) {
       System.out.println("PApplet.onDestroy() called");
     }
-    super.onDestroy();
     //finish();
   }
 
@@ -1809,9 +1796,6 @@ public class PApplet extends Fragment implements PConstants, Runnable {
           } catch (InstantiationException e) {
             e.printStackTrace();
             throw new RuntimeException(e.getMessage());
-          } catch (java.lang.InstantiationException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
           } catch (IllegalArgumentException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -3179,7 +3163,7 @@ public class PApplet extends Fragment implements PConstants, Runnable {
    */
   public void link(String url, String frameTitle) {
     Intent viewIntent = new Intent("android.intent.action.VIEW", Uri.parse(url));
-    startActivity(viewIntent);
+    activity.startActivity(viewIntent);
   }
 
 
@@ -8000,22 +7984,18 @@ public class PApplet extends Fragment implements PConstants, Runnable {
   }
 
 
-  private void tellPDE(final String message) {
+  public void tellPDE(final String message) {
     Log.i(activity.getComponentName().getPackageName(), "PROCESSING " + message);
   }
 
 
-  @Override
   public void onStart() {
     tellPDE("onStart");
-    super.onStart();
   }
 
 
-  @Override
   public void onStop() {
     tellPDE("onStop");
-    super.onStop();
   }
 
 

--- a/src/processing/mode/android/AndroidBuild.java
+++ b/src/processing/mode/android/AndroidBuild.java
@@ -171,6 +171,7 @@ class AndroidBuild extends JavaBuild {
 
       final File resFolder = new File(tmpFolder, "res");
       writeRes(resFolder, sketchClassName);
+      writeSketchFragment(srcFolder);
       writeMainActivity(srcFolder);
 
 
@@ -864,6 +865,73 @@ class AndroidBuild extends JavaBuild {
     return result;
   }
 
+  private void writeSketchFragment(final File srcDirectory) {
+    File sketchFragmentFile = new File(new File(srcDirectory, manifest.getPackageName().replace(".", "/")),
+        "SketchFragment.java");
+    final PrintWriter writer = PApplet.createWriter(sketchFragmentFile);
+    writer.println("package " + manifest.getPackageName() +";");
+    writer.println("import android.app.Activity;");
+    writer.println("import android.os.Bundle;");
+    writer.println("import android.view.LayoutInflater;");
+    writer.println("import android.view.View;");
+    writer.println("import android.view.ViewGroup;");
+    writer.println("import android.content.res.Configuration;");
+    writer.println("import android.app.Fragment;");
+    writer.println("import processing.core.PApplet;");
+    writer.println("public class SketchFragment extends Fragment {");
+    writer.println("  PApplet mPApplet;");
+    writer.println("  @Override");
+    writer.println("  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {");
+    writer.println("    mPApplet = new " + sketchClassName + "();");
+    writer.println("    Activity activity = getActivity();");
+    writer.println("    View rootView = mPApplet.onCreateView(activity);");
+    writer.println("    return rootView;");
+    writer.println("  }");
+
+    writer.println("  @Override");
+    writer.println("  public void onConfigurationChanged(Configuration newConfig) {");
+    writer.println("    super.onConfigurationChanged(newConfig);");
+    writer.println("  }");
+
+    writer.println("  @Override");
+    writer.println("  public void onResume() {");
+    writer.println("    super.onResume();");
+    writer.println("    mPApplet.onResume();");
+    writer.println("  }");
+
+    writer.println("  @Override");
+    writer.println("  public void onPause() {");
+    writer.println("    super.onPause();");
+    writer.println("    mPApplet.onPause();");
+    writer.println("  }");
+
+    writer.println("  @Override");
+    writer.println("    public void onDestroy() {");
+    writer.println("      mPApplet.onDestroy();");
+    writer.println("      super.onDestroy();");
+    writer.println("    }");
+
+    writer.println("  @Override");
+    writer.println("  public void onStart() {");
+    writer.println("    mPApplet.tellPDE(\"onStart\");");
+    writer.println("    super.onStart();");
+    writer.println("  }");
+
+    writer.println("  @Override");
+    writer.println("  public void onStop() {");
+    writer.println("    mPApplet.tellPDE(\"onStop\");");
+    writer.println("    super.onStop();");
+    writer.println("  }");
+
+    writer.println("  public void onBackPressed() {");
+    writer.println("    mPApplet.onBackPressed();");
+    writer.println("  }");
+
+    writer.println("}");
+    writer.flush();
+    writer.close();
+
+  }
 
   private void writeMainActivity(final File srcDirectory) {
     File mainActivityFile = new File(new File(srcDirectory, manifest.getPackageName().replace(".", "/")),
@@ -877,9 +945,9 @@ class AndroidBuild extends JavaBuild {
     writer.println("import android.widget.FrameLayout;");
     writer.println("import android.view.ViewGroup.LayoutParams;");
     writer.println("import  android.app.FragmentTransaction;");
-    writer.println("import processing.core.PApplet;");
+    writer.println("import android.app.Fragment;");
     writer.println("public class MainActivity extends Activity {");
-    writer.println("    PApplet fragment;");
+    writer.println("    SketchFragment fragment;");
     writer.println("    private static final String MAIN_FRAGMENT_TAG = \"main_fragment\";");
     writer.println("    int viewId = 0x1000;");
     writer.println("    @Override");
@@ -896,11 +964,11 @@ class AndroidBuild extends JavaBuild {
     writer.println("        setContentView(frame, new LayoutParams(LayoutParams.MATCH_PARENT, "
         + "LayoutParams.MATCH_PARENT));");
     writer.println("        if (savedInstanceState == null) {");
-    writer.println("            fragment = new " + sketchClassName + "();");
+    writer.println("            fragment = new SketchFragment();");
     writer.println("            FragmentTransaction ft = getFragmentManager().beginTransaction();");
     writer.println("            ft.add(frame.getId(), fragment, MAIN_FRAGMENT_TAG).commit();");
     writer.println("        } else {");
-    writer.println("            fragment = (PApplet) getFragmentManager().findFragmentByTag(MAIN_FRAGMENT_TAG);");
+    writer.println("            fragment = (SketchFragment) getFragmentManager().findFragmentByTag(MAIN_FRAGMENT_TAG);");
     writer.println("        }");
     writer.println("    }");
     writer.println("    @Override");


### PR DESCRIPTION
Currently, PApplet extends Fragment in android mode while it doesn't extends anything in java mode.
This is to make sure PApplet follows the same API in both android and java mode.
Signed-off-by: Suhaib Khan <suheb.work@gmail.com>