### PR TITLE
Fix build if the cardboard/library folder doesn't exist

### DIFF
--- a/libraries/cardboard/build.gradle
+++ b/libraries/cardboard/build.gradle
@@ -46,9 +46,12 @@ import static java.nio.file.StandardCopyOption.*;
 
 task dist {
     doLast {
+        File cardBoardJar = file("library/cardboard.jar");
+        //create intermediate folder if they don't exist
+        cardBoardJar.mkdirs();
         // make copy of jar file to library folder
         Files.copy(file("$buildDir/libs/cardboard.jar").toPath(),
-                   file("library/cardboard.jar").toPath(), REPLACE_EXISTING);             
+                   cardBoardJar.toPath(), REPLACE_EXISTING);             
     }
 }
 

--- a/libraries/cardboard/build.xml
+++ b/libraries/cardboard/build.xml
@@ -10,7 +10,8 @@
   </target>
 
   <target name="build" depends="sdk_chatter,compile" description="Build cardboard library for Processing Android" >
-  	<jar basedir="bin" destfile="library/cardboard.jar" />
+    <mkdir dir="library" />
+    <jar basedir="bin" destfile="library/cardboard.jar" />
   </target>
 
   <target name="sdk_chatter" unless="env.ANDROID_SDK">


### PR DESCRIPTION
@codeanticode I did not test the ant build if it was broken in the first place at all. I'm unable to build using ant altogether because of some other issues.
Gradle is working smooth though. :)