### PR TITLE
Proposal to fix push/pop matrix op in default mode.

### DIFF
--- a/core/src/processing/a2d/PGraphicsAndroid2D.java
+++ b/core/src/processing/a2d/PGraphicsAndroid2D.java
@@ -1433,6 +1433,7 @@ public class PGraphicsAndroid2D extends PGraphics {
     transform.get(transformStack[transformCount]);
     transformCount++;
 //    canvas.save(Canvas.MATRIX_SAVE_FLAG);
+    canvas.save(); 
   }
 
 
@@ -1445,8 +1446,8 @@ public class PGraphicsAndroid2D extends PGraphics {
     transformCount--;
     transform.set(transformStack[transformCount]);
     updateTmpMatrix();
-    canvas.setMatrix(tmpMatrix);
-//    canvas.restore();
+    //canvas.setMatrix(tmpMatrix);
+    canvas.restore();
   }
 
 
@@ -1464,7 +1465,7 @@ public class PGraphicsAndroid2D extends PGraphics {
 
   @Override
   public void rotate(float angle) {
-    transform.rotate(angle * RAD_TO_DEG);
+    transform.rotate(angle);
     canvas.rotate(angle * RAD_TO_DEG);
   }
 

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -5792,6 +5792,7 @@ public class PGraphicsOpenGL extends PGraphics {
 
     // Copies the pixels
     loadPixels();
+    if(sourceImage.pixels==null) sourceImage.loadPixels();
     int sourceOffset = sourceY * sourceImage.pixelWidth + sourceX;
     int targetOffset = targetY * pixelWidth + targetX;
     for (int y = sourceY; y < sourceY + sourceHeight; y++) {


### PR DESCRIPTION
Proposal to fix push/pop matrix op in default mode. Summary: `Canvas.setMatrix()` unpredictable as described in docs. Fixes ticket #445 but this will probably open issue #287.

This changes shouldn't affect P2D/P3D as changes are contained in `PGraphicsAndroid2D.java`. Test sketch in ticket #445.

Since `Canvas.save()` and `Canvas.restore()` are being restored, more testing across multiple devices will be required.

Kf