### PR TITLE
Fixing dangling animation threads

### DIFF
--- a/core/src/processing/android/PWallpaper.java
+++ b/core/src/processing/android/PWallpaper.java
@@ -32,6 +32,7 @@ import android.view.Display;
 import android.graphics.Point;
 import android.graphics.Rect;
 
+
 public class PWallpaper extends WallpaperService implements AppComponent {
   private Point size;
   private DisplayMetrics metrics;
@@ -209,7 +210,7 @@ public class PWallpaper extends WallpaperService implements AppComponent {
       // surface. If you have a rendering thread that directly accesses the
       // surface, you must ensure that thread is no longer touching the Surface
       // before returning from this function.
-      super.onSurfaceDestroyed(holder);
+        super.onSurfaceDestroyed(holder);
     }
 
 

--- a/core/src/processing/android/PWallpaper.java
+++ b/core/src/processing/android/PWallpaper.java
@@ -119,12 +119,16 @@ public class PWallpaper extends WallpaperService implements AppComponent {
   @Override
   public void onDestroy() {
     super.onDestroy();
-    if (engine != null) engine.onDestroy();
+
+    if (engine != null){
+      //engine.sketch = null;
+      engine.onDestroy();
+    }
   }
 
 
   public class WallpaperEngine extends Engine implements ServiceEngine {
-    private PApplet sketch;
+    PApplet sketch;
     private float xOffset, xOffsetStep;
     private float yOffset, yOffsetStep;
     private int xPixelOffset, yPixelOffset;

--- a/studio/apps/wallpaper/src/main/AndroidManifest.xml
+++ b/studio/apps/wallpaper/src/main/AndroidManifest.xml
@@ -10,5 +10,11 @@
             <meta-data android:name="android.service.wallpaper" android:resource="@xml/wallpaper"/>
         </service>
         <activity android:name="processing.android.PermissionRequestor"/>
+        <activity android:name=".DebuggerEntryPointActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/studio/apps/wallpaper/src/main/java/wallpaper/DebuggerEntryPointActivity.java
+++ b/studio/apps/wallpaper/src/main/java/wallpaper/DebuggerEntryPointActivity.java
@@ -1,0 +1,12 @@
+package wallpaper;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+public class DebuggerEntryPointActivity extends Activity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+}


### PR DESCRIPTION
This contains two additions (pull requests are not supposed to do this, but it's my first one so bear with me):
* An empty activity is added to the wallpaper project. This provides the opportunity to attach a debugger before the wallpaper ist run the first time and thus allows to reach breakpoints in the sketch's setup routine.
* Changes to `core/src/processing/core/PSurfaceNone.java` that fix the [dangling animation threads](https://github.com/processing/processing-android/issues/468) issue.