### PR TITLE
maven to maven-publish

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,46 +1,64 @@
+import org.apache.tools.ant.Project
 import java.nio.file.Files
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 apply plugin: 'aar'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 dependencies {
     implementation name: "android"
-
     implementationAar "androidx.legacy:legacy-support-v4:${v4legacyVersion}"
-    implementationAar "com.google.android.support:wearable:${wearVersion}"  
+    implementationAar "com.google.android.support:wearable:${wearVersion}"
 }
 
-task createPom {
-    pom {
-       project {
-           groupId "org.p5android"
-           artifactId "processing-core"
-           version "${modeVersion}"
-           packaging "jar"
-           licenses {
-               license {
-                   name "GNU Lesser General Public License, version 2.1"
-                   url "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
-                   distribution "repo"
-               }
-           }
-           dependencies {
-               dependency {
-                   groupId "androidx.legacy"
-                   artifactId "legacy-support-v4"
-                   version "${v4legacyVersion}"
-                   scope "implementation"
-               }
-               dependency {
-                   groupId "com.google.android.support"
-                   artifactId "wearable"
-                   version "${wearVersion}"
-                   scope "implementation"
-               }               
-           }
+task sourceJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = "sources"
+}
+
+publishing {
+    publications {
+        corePublication(MavenPublication) {
+            from components.java
+            artifact sourceJar
+            pom {
+                groupId = "org.p5android"
+                artifactId = "processing-core"
+                version = "${modeVersion}"
+                packaging = "jar"
+                // description = "Processing Android Core"
+                // url = "http://www.example.com/project"
+                licenses {
+                    license {
+                        name = "GNU Lesser General Public License, version 2.1"
+                        url = "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
+                        distribution = "repo"
+                    }
+                }
+            }
+            pom.withXml {   // Only one dependency is added under dependancies node
+                asNode().remove(asNode().get("dependencies")) //removing dependencies node
+                // inserting the dependencies node
+                def dependenciesNode = asNode().appendNode('dependencies')
+                // start adding dependency nodes inside dependencies node
+                def dependencyNode = dependenciesNode.appendNode('dependency')
+                dependencyNode.appendNode('groupId', 'androidx.legacy')
+                dependencyNode.appendNode('artifactId', 'legacy-support-v4')
+                dependencyNode.appendNode('version', '1.0.0')
+                dependencyNode.appendNode('scope', 'implementation')
+
+                def dependencyNode2 = dependenciesNode.appendNode('dependency')
+                dependencyNode2.appendNode('groupId', 'com.google.android.support')
+                dependencyNode2.appendNode('artifactId', 'wearable')
+                dependencyNode2.appendNode('version', '2.8.1')
+                dependencyNode2.appendNode('scope', 'implementation')
+
+                def dependencyNode3 = dependenciesNode.appendNode('dependency')
+                dependencyNode3.appendNode('artifactId', 'android')
+                dependencyNode3.appendNode('scope', 'runtime')
+            }
         }
-    }.writeTo("dist/processing-core-${modeVersion}.pom")
+    }
 }
 
 sourceSets {
@@ -80,25 +98,38 @@ clean.doFirst {
 }
 
 compileJava.doFirst {
-    String[] deps = ["wearable.jar"]                    
+    String[] deps = ["wearable.jar"]
     for (String fn : deps) {
         Files.copy(file("${rootDir}/build/libs/" + fn).toPath(),
-                   file("${rootDir}/mode/mode/" + fn).toPath(), REPLACE_EXISTING)
+                file("${rootDir}/mode/mode/" + fn).toPath(), REPLACE_EXISTING)
     }
 }
 
 build.doLast {
-    // Copying core jar as zip inside the mode folder
+    // If xml doesn't exist
+    def pomfile = file("${buildDir}/publications/corePublication/pom-default.xml")
+    if (!pomfile.exists()) {
+        println("***************************************************************************************\n" +
+                "*                                                                                     *\n" +
+                "*   File not found: root/core/build/publications/corePublication/pom-default.xml      *\n" +
+                "*   First execute the following command to generate the file:                         *\n" +
+                "*   gradle generatePomFileForcorePublicationPublication                               *\n" +
+                "*                                                                                     *\n" +
+                "***************************************************************************************"
+        )
+    }
+    // // Copying core jar as zip inside the mode folder
     Files.copy(file("${buildDir}/libs/core.jar").toPath(),
-               file("${coreZipPath}").toPath(), REPLACE_EXISTING)
-
-    // Copying the files for release on JCentral
+            file("${coreZipPath}").toPath(), REPLACE_EXISTING)
+    // // Copying the files for release on JCentral
     File distFolder = file("dist")
     distFolder.mkdirs()
     Files.copy(file("${buildDir}/libs/core.jar").toPath(),
-               file("dist/processing-core-${modeVersion}.jar").toPath(), REPLACE_EXISTING)
+            file("dist/processing-core-${modeVersion}.jar").toPath(), REPLACE_EXISTING)
     Files.copy(file("${buildDir}/libs/core-sources.jar").toPath(),
-               file("dist/processing-core-${modeVersion}-sources.jar").toPath(), REPLACE_EXISTING)
+            file("dist/processing-core-${modeVersion}-sources.jar").toPath(), REPLACE_EXISTING)
     Files.copy(file("${buildDir}/libs/core.jar.MD5").toPath(),
-               file("dist/processing-core-${modeVersion}.jar.md5").toPath(), REPLACE_EXISTING)
+            file("dist/processing-core-${modeVersion}.jar.md5").toPath(), REPLACE_EXISTING)
+    Files.copy(file("${buildDir}/publications/corePublication/pom-default.xml").toPath(),
+           file("dist/processing-core-${modeVersion}.pom").toPath(), REPLACE_EXISTING)
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -37,20 +37,20 @@ publishing {
                 }
             }
             pom.withXml {   // Only one dependency is added under dependancies node
-                asNode().remove(asNode().get("dependencies")) //removing dependencies node
+                asNode().remove(asNode().get("dependencies")) // removing dependencies node
                 // inserting the dependencies node
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // start adding dependency nodes inside dependencies node
                 def dependencyNode = dependenciesNode.appendNode('dependency')
                 dependencyNode.appendNode('groupId', 'androidx.legacy')
                 dependencyNode.appendNode('artifactId', 'legacy-support-v4')
-                dependencyNode.appendNode('version', '1.0.0')
+                dependencyNode.appendNode('version', "${v4legacyVersion}")
                 dependencyNode.appendNode('scope', 'implementation')
 
                 def dependencyNode2 = dependenciesNode.appendNode('dependency')
                 dependencyNode2.appendNode('groupId', 'com.google.android.support')
                 dependencyNode2.appendNode('artifactId', 'wearable')
-                dependencyNode2.appendNode('version', '2.8.1')
+                dependencyNode2.appendNode('version', "${wearVersion}")
                 dependencyNode2.appendNode('scope', 'implementation')
 
                 def dependencyNode3 = dependenciesNode.appendNode('dependency')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,16 +11,27 @@ dependencies {
     implementationAar "com.google.android.support:wearable:${wearVersion}"
 }
 
-task sourceJar(type: Jar) {
-    from sourceSets.main.allJava
-    archiveClassifier = "sources"
+sourceSets {
+    main {
+        java {
+            srcDirs = ["src/"]
+        }
+        resources {
+            srcDirs = ["src/"]
+        }
+    }
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = "sources"
+    from sourceSets.main.allSource
 }
 
 publishing {
     publications {
         corePublication(MavenPublication) {
             from components.java
-            artifact sourceJar
+            artifact sourcesJar
             pom {
                 groupId = "org.p5android"
                 artifactId = "processing-core"
@@ -59,22 +70,6 @@ publishing {
             }
         }
     }
-}
-
-sourceSets {
-    main {
-        java {
-            srcDirs = ["src/"]
-        }
-        resources {
-            srcDirs = ["src/"]
-        }
-    }
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
 }
 
 // Does not work because of Processing-specific tags in source code, such as @webref

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -52,21 +52,21 @@ publishing {
                 // inserting the dependencies node
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // start adding dependency nodes inside dependencies node
-                def dependencyNode = dependenciesNode.appendNode('dependency')
-                dependencyNode.appendNode('groupId', 'androidx.legacy')
-                dependencyNode.appendNode('artifactId', 'legacy-support-v4')
-                dependencyNode.appendNode('version', "${v4legacyVersion}")
-                dependencyNode.appendNode('scope', 'implementation')
+                def androidLegacyDependancyNode = dependenciesNode.appendNode('dependency')
+                androidLegacyDependancyNode.appendNode('groupId', 'androidx.legacy')
+                androidLegacyDependancyNode.appendNode('artifactId', 'legacy-support-v4')
+                androidLegacyDependancyNode.appendNode('version', "${v4legacyVersion}")
+                androidLegacyDependancyNode.appendNode('scope', 'implementation')
 
-                def dependencyNode2 = dependenciesNode.appendNode('dependency')
-                dependencyNode2.appendNode('groupId', 'com.google.android.support')
-                dependencyNode2.appendNode('artifactId', 'wearable')
-                dependencyNode2.appendNode('version', "${wearVersion}")
-                dependencyNode2.appendNode('scope', 'implementation')
+                def wearableDependencyNode = dependenciesNode.appendNode('dependency')
+                wearableDependencyNode.appendNode('groupId', 'com.google.android.support')
+                wearableDependencyNode.appendNode('artifactId', 'wearable')
+                wearableDependencyNode.appendNode('version', "${wearVersion}")
+                wearableDependencyNode.appendNode('scope', 'implementation')
 
-                def dependencyNode3 = dependenciesNode.appendNode('dependency')
-                dependencyNode3.appendNode('artifactId', 'android')
-                dependencyNode3.appendNode('scope', 'runtime')
+                def androidRuntimeDependencyNode = dependenciesNode.appendNode('dependency')
+                androidRuntimeDependencyNode.appendNode('artifactId', 'android')
+                androidRuntimeDependencyNode.appendNode('scope', 'runtime')
             }
         }
     }

--- a/mode/libraries/ar/build.gradle
+++ b/mode/libraries/ar/build.gradle
@@ -43,13 +43,13 @@ publishing {
                 def dependencyNode = dependenciesNode.appendNode('dependency')
                 dependencyNode.appendNode('groupId', 'org.p5android')
                 dependencyNode.appendNode('artifactId', 'processing-core')
-                dependencyNode.appendNode('version', '4.2.0')
+                dependencyNode.appendNode('version', "${modeVersion}")
                 dependencyNode.appendNode('scope', 'implementation')
 
                 def dependencyNode2 = dependenciesNode.appendNode('dependency')
                 dependencyNode2.appendNode('groupId', 'com.google.ar')
                 dependencyNode2.appendNode('artifactId', 'core')
-                dependencyNode2.appendNode('version', '1.22.0')
+                dependencyNode2.appendNode('version', "${garVersion}")
                 dependencyNode2.appendNode('scope', 'implementation')
             }
 

--- a/mode/libraries/ar/build.gradle
+++ b/mode/libraries/ar/build.gradle
@@ -2,47 +2,60 @@ import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 apply plugin: 'aar'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 dependencies {
     compileOnly name: "android"
-
     compileOnly "org.p5android:processing-core:${modeVersion}"
-
     implementationAar "com.google.ar:core:${garVersion}"
 }
 
-task createPom {
-    pom {
-       project {
-           groupId "org.p5android"
-           artifactId "processing-ar"
-           version "${arLibVersion}"
-           packaging "jar"
-           licenses {
-               license {
-                   name "GNU Lesser General Public License, version 2.1"
-                   url "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
-                   distribution "repo"
-               }
-           }
-           dependencies {
-               dependency {
-                   groupId "org.p5android"
-                   artifactId "processing-core"
-                   version "${modeVersion}"
-                   scope "implementation"
-               }
+task sourceJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = "sources"
+}
 
-               dependency {
-                   groupId "com.google.ar"
-                   artifactId "core"
-                   version "${garVersion}"
-                   scope "implementation"
-               }            
-           }
+publishing {
+    publications {
+        arPublication(MavenPublication) {
+            from components.java
+            artifact sourceJar
+            pom {
+                groupId = "org.p5android"
+                artifactId = "processing-ar"
+                version = "${arLibVersion}"
+                packaging = "jar"
+                // description = "Processing Android Core"
+                // url = "http://www.example.com/project"
+                licenses {
+                    license {
+                        name = "GNU Lesser General Public License, version 2.1"
+                        url = "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
+                        distribution = "repo"
+                    }
+                }
+            }
+
+            pom.withXml {
+                // inserting the dependencies node
+                def dependenciesNode = asNode().appendNode('dependencies')
+                // start adding dependency nodes inside dependencies node
+                def dependencyNode = dependenciesNode.appendNode('dependency')
+                dependencyNode.appendNode('groupId', 'org.p5android')
+                dependencyNode.appendNode('artifactId', 'processing-core')
+                dependencyNode.appendNode('version', '4.2.0')
+                dependencyNode.appendNode('scope', 'implementation')
+
+                def dependencyNode2 = dependenciesNode.appendNode('dependency')
+                dependencyNode2.appendNode('groupId', 'com.google.ar')
+                dependencyNode2.appendNode('artifactId', 'core')
+                dependencyNode2.appendNode('version', '1.22.0')
+                dependencyNode2.appendNode('scope', 'implementation')
+            }
+
+
         }
-    }.writeTo("dist/processing-ar-${arLibVersion}.pom")
+    }
 }
 
 sourceSets {
@@ -56,11 +69,6 @@ sourceSets {
     }
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
-}
-
 // Does not work because of Processing-specific tags in source code, such as @webref
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = "javadoc"
@@ -69,7 +77,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 artifacts {
 //     archives javadocJar
-    archives sourcesJar
+    archives sourceJar
 }
 
 jar.doLast { task ->
@@ -92,13 +100,24 @@ compileJava.doFirst {
 }
 
 build.doLast {
+    // If xml doesn't exist
+    def pomfile = file("${buildDir}/publications/arPublication/pom-default.xml")
+    if (!pomfile.exists()) {
+        println("**********************************************************************************************\n" +
+                "*                                                                                            *\n" +
+                "*   File not found: root/mode/libraries/ar/build/publications/arPublication/pom-default.xml  *\n" +
+                "*   First execute the following command to generate the file:                                *\n" +
+                "*   gradle generatePomFileForarPublicationPublication                                        *\n" +
+                "*                                                                                            *\n" +
+                "**********************************************************************************************"
+        )
+    }
     // Copying ar jar to library folder
     File arJar = file("library/ar.jar")
     arJar.mkdirs();
     Files.copy(file("$buildDir/libs/ar.jar").toPath(),
-               arJar.toPath(), REPLACE_EXISTING);   
-
-    // // Copying the files for release on JCentral
+               arJar.toPath(), REPLACE_EXISTING);
+    // Copying the files for release on JCentral
     File distFolder = file("dist");
     distFolder.mkdirs();
     Files.copy(file("$buildDir/libs/ar.jar").toPath(),
@@ -107,4 +126,6 @@ build.doLast {
                file("dist/processing-ar-${arLibVersion}-sources.jar").toPath(), REPLACE_EXISTING);
     Files.copy(file("$buildDir/libs/ar.jar.MD5").toPath(),
                file("dist/processing-ar-${arLibVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    Files.copy(file("${buildDir}/publications/arPublication/pom-default.xml").toPath(),
+            file("dist/processing-ar-${arLibVersion}.pom").toPath(), REPLACE_EXISTING)
 }

--- a/mode/libraries/ar/build.gradle
+++ b/mode/libraries/ar/build.gradle
@@ -40,20 +40,18 @@ publishing {
                 // inserting the dependencies node
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // start adding dependency nodes inside dependencies node
-                def dependencyNode = dependenciesNode.appendNode('dependency')
-                dependencyNode.appendNode('groupId', 'org.p5android')
-                dependencyNode.appendNode('artifactId', 'processing-core')
-                dependencyNode.appendNode('version', "${modeVersion}")
-                dependencyNode.appendNode('scope', 'implementation')
+                def processingCoreDependencyNode = dependenciesNode.appendNode('dependency')
+                processingCoreDependencyNode.appendNode('groupId', 'org.p5android')
+                processingCoreDependencyNode.appendNode('artifactId', 'processing-core')
+                processingCoreDependencyNode.appendNode('version', "${modeVersion}")
+                processingCoreDependencyNode.appendNode('scope', 'implementation')
 
-                def dependencyNode2 = dependenciesNode.appendNode('dependency')
-                dependencyNode2.appendNode('groupId', 'com.google.ar')
-                dependencyNode2.appendNode('artifactId', 'core')
-                dependencyNode2.appendNode('version', "${garVersion}")
-                dependencyNode2.appendNode('scope', 'implementation')
+                def googleARDependencyNode = dependenciesNode.appendNode('dependency')
+                googleARDependencyNode.appendNode('groupId', 'com.google.ar')
+                googleARDependencyNode.appendNode('artifactId', 'core')
+                googleARDependencyNode.appendNode('version', "${garVersion}")
+                googleARDependencyNode.appendNode('scope', 'implementation')
             }
-
-
         }
     }
 }

--- a/mode/libraries/vr/build.gradle
+++ b/mode/libraries/vr/build.gradle
@@ -2,7 +2,7 @@ import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 apply plugin: 'aar'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 dependencies {
     compileOnly name: "android"
@@ -13,6 +13,7 @@ dependencies {
     implementationAar "com.google.vr:sdk-base:${gvrVersion}" 
 }
 
+/*
 task createPom {
     pom {
        project {
@@ -52,6 +53,59 @@ task createPom {
     }.writeTo("dist/processing-vr-${vrLibVersion}.pom")
 }
 
+
+ */
+
+task sourceJar(type: Jar, dependsOn: classes) {
+    classifier = "sources"
+    from sourceSets.main.allSource
+}
+
+publishing {
+    publications {
+        vrPublication(MavenPublication) {
+            from components.java
+            artifact sourceJar
+            pom {
+                groupId = "org.p5android"
+                artifactId = "processing-vr"
+                version = "${vrLibVersion}"
+                packaging = "jar"
+                licenses {
+                    license {
+                        name = "GNU Lesser General Public License, version 2.1"
+                        url = "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
+                        distribution = "repo"
+                    }
+                }
+            }
+
+            pom.withXml {
+                // inserting the dependencies node
+                def dependenciesNode = asNode().appendNode('dependencies')
+                // start adding dependency nodes inside dependencies node
+                def dependencyNode = dependenciesNode.appendNode('dependency')
+                dependencyNode.appendNode('groupId', 'org.p5android')
+                dependencyNode.appendNode('artifactId', 'processing-core')
+                dependencyNode.appendNode('version', '4.2.0')
+                dependencyNode.appendNode('scope', 'implementation')
+
+                def dependencyNode2 = dependenciesNode.appendNode('dependency')
+                dependencyNode2.appendNode('groupId', 'com.google.vr')
+                dependencyNode2.appendNode('artifactId', 'sdk-base')
+                dependencyNode2.appendNode('version', '1.180.0')
+                dependencyNode2.appendNode('scope', 'implementation')
+
+                def dependencyNode3 = dependenciesNode.appendNode('dependency')
+                dependencyNode3.appendNode('groupId', 'com.google.vr')
+                dependencyNode3.appendNode('artifactId', 'sdk-audio')
+                dependencyNode3.appendNode('version', '1.180.0')
+                dependencyNode3.appendNode('scope', 'implementation')
+            }
+        }
+    }
+}
+
 sourceSets {
     main {
         java {
@@ -60,10 +114,6 @@ sourceSets {
     }
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
-}
 
 // Does not work because of Processing-specific tags in source code, such as @webref
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -73,7 +123,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 artifacts {
 //     archives javadocJar
-    archives sourcesJar
+    archives sourceJar
 }
 
 jar.doLast { task ->
@@ -100,6 +150,18 @@ compileJava.doFirst {
 
 
 build.doLast {
+    // If xml doesn't exist
+    def pomfile = file("${buildDir}/publications/corePublication/pom-default.xml")
+    if (!pomfile.exists()) {
+        println("************************************************************************************************\n" +
+                "*                                                                                              *\n" +
+                "*   File not found: root/mode/libraries/vr/build/publications/corePublication/pom-default.xml  *\n" +
+                "*   First execute the following command to generate the file:                                  *\n" +
+                "*   gradle generatePomFileForvrPublicationPublication                                          *\n" +
+                "*                                                                                              *\n" +
+                "************************************************************************************************"
+        )
+    }
     // // Copying vr jar to library folder
     File vrJar = file("library/vr.jar")
     vrJar.mkdirs();
@@ -115,4 +177,6 @@ build.doLast {
                file("dist/processing-vr-${vrLibVersion}-sources.jar").toPath(), REPLACE_EXISTING);
     Files.copy(file("$buildDir/libs/vr.jar.MD5").toPath(),
                file("dist/processing-vr-${vrLibVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    Files.copy(file("$buildDir/publications/corePublication/pom-default.xml").toPath(),
+            file("dist/processing-vr-${vrLibVersion}.pom").toPath(), REPLACE_EXISTING);
 }

--- a/mode/libraries/vr/build.gradle
+++ b/mode/libraries/vr/build.gradle
@@ -41,23 +41,23 @@ publishing {
                 // inserting the dependencies node
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // start adding dependency nodes inside dependencies node
-                def dependencyNode = dependenciesNode.appendNode('dependency')
-                dependencyNode.appendNode('groupId', 'org.p5android')
-                dependencyNode.appendNode('artifactId', 'processing-core')
-                dependencyNode.appendNode('version', "${modeVersion}")
-                dependencyNode.appendNode('scope', 'implementation')
+                def processingCoreDependencyNode = dependenciesNode.appendNode('dependency')
+                processingCoreDependencyNode.appendNode('groupId', 'org.p5android')
+                processingCoreDependencyNode.appendNode('artifactId', 'processing-core')
+                processingCoreDependencyNode.appendNode('version', "${modeVersion}")
+                processingCoreDependencyNode.appendNode('scope', 'implementation')
 
-                def dependencyNode2 = dependenciesNode.appendNode('dependency')
-                dependencyNode2.appendNode('groupId', 'com.google.vr')
-                dependencyNode2.appendNode('artifactId', 'sdk-base')
-                dependencyNode2.appendNode('version', "${gvrVersion}")
-                dependencyNode2.appendNode('scope', 'implementation')
+                def googleVRDependencyNode = dependenciesNode.appendNode('dependency')
+                googleVRDependencyNode.appendNode('groupId', 'com.google.vr')
+                googleVRDependencyNode.appendNode('artifactId', 'sdk-base')
+                googleVRDependencyNode.appendNode('version', "${gvrVersion}")
+                googleVRDependencyNode.appendNode('scope', 'implementation')
 
-                def dependencyNode3 = dependenciesNode.appendNode('dependency')
-                dependencyNode3.appendNode('groupId', 'com.google.vr')
-                dependencyNode3.appendNode('artifactId', 'sdk-audio')
-                dependencyNode3.appendNode('version', "${gvrVersion}")
-                dependencyNode3.appendNode('scope', 'implementation')
+                def googleVRAudioDependencyNode = dependenciesNode.appendNode('dependency')
+                googleVRAudioDependencyNode.appendNode('groupId', 'com.google.vr')
+                googleVRAudioDependencyNode.appendNode('artifactId', 'sdk-audio')
+                googleVRAudioDependencyNode.appendNode('version', "${gvrVersion}")
+                googleVRAudioDependencyNode.appendNode('scope', 'implementation')
             }
         }
     }

--- a/mode/libraries/vr/build.gradle
+++ b/mode/libraries/vr/build.gradle
@@ -44,19 +44,19 @@ publishing {
                 def dependencyNode = dependenciesNode.appendNode('dependency')
                 dependencyNode.appendNode('groupId', 'org.p5android')
                 dependencyNode.appendNode('artifactId', 'processing-core')
-                dependencyNode.appendNode('version', '4.2.0')
+                dependencyNode.appendNode('version', "${modeVersion}")
                 dependencyNode.appendNode('scope', 'implementation')
 
                 def dependencyNode2 = dependenciesNode.appendNode('dependency')
                 dependencyNode2.appendNode('groupId', 'com.google.vr')
                 dependencyNode2.appendNode('artifactId', 'sdk-base')
-                dependencyNode2.appendNode('version', '1.180.0')
+                dependencyNode2.appendNode('version', "${gvrVersion}")
                 dependencyNode2.appendNode('scope', 'implementation')
 
                 def dependencyNode3 = dependenciesNode.appendNode('dependency')
                 dependencyNode3.appendNode('groupId', 'com.google.vr')
                 dependencyNode3.appendNode('artifactId', 'sdk-audio')
-                dependencyNode3.appendNode('version', '1.180.0')
+                dependencyNode3.appendNode('version', "${gvrVersion}")
                 dependencyNode3.appendNode('scope', 'implementation')
             }
         }

--- a/mode/libraries/vr/build.gradle
+++ b/mode/libraries/vr/build.gradle
@@ -1,5 +1,5 @@
 import java.nio.file.Files
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 apply plugin: 'aar'
 apply plugin: 'maven-publish'
@@ -177,6 +177,6 @@ build.doLast {
                file("dist/processing-vr-${vrLibVersion}-sources.jar").toPath(), REPLACE_EXISTING);
     Files.copy(file("$buildDir/libs/vr.jar.MD5").toPath(),
                file("dist/processing-vr-${vrLibVersion}.jar.md5").toPath(), REPLACE_EXISTING);
-    Files.copy(file("$buildDir/publications/corePublication/pom-default.xml").toPath(),
+    Files.copy(file("$buildDir/publications/vrPublication/pom-default.xml").toPath(),
             file("dist/processing-vr-${vrLibVersion}.pom").toPath(), REPLACE_EXISTING);
 }

--- a/mode/libraries/vr/build.gradle
+++ b/mode/libraries/vr/build.gradle
@@ -13,49 +13,6 @@ dependencies {
     implementationAar "com.google.vr:sdk-base:${gvrVersion}" 
 }
 
-/*
-task createPom {
-    pom {
-       project {
-           groupId "org.p5android"
-           artifactId "processing-vr"
-           version "${vrLibVersion}"
-           packaging "jar"
-           licenses {
-               license {
-                   name "GNU Lesser General Public License, version 2.1"
-                   url "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
-                   distribution "repo"
-               }
-           }
-           dependencies {
-               dependency {
-                   groupId "org.p5android"
-                   artifactId "processing-core"
-                   version "${modeVersion}"
-                   scope "implementation"
-               }
-
-               dependency {
-                   groupId "com.google.vr"
-                   artifactId "sdk-base"
-                   version "${gvrVersion}"
-                   scope "implementation"
-               }
-               dependency {
-                   groupId "com.google.vr"
-                   artifactId "sdk-audio"
-                   version "${gvrVersion}"
-                   scope "implementation"
-               }               
-           }
-        }
-    }.writeTo("dist/processing-vr-${vrLibVersion}.pom")
-}
-
-
- */
-
 task sourceJar(type: Jar, dependsOn: classes) {
     classifier = "sources"
     from sourceSets.main.allSource
@@ -151,7 +108,7 @@ compileJava.doFirst {
 
 build.doLast {
     // If xml doesn't exist
-    def pomfile = file("${buildDir}/publications/corePublication/pom-default.xml")
+    def pomfile = file("${buildDir}/publications/vrPublication/pom-default.xml")
     if (!pomfile.exists()) {
         println("************************************************************************************************\n" +
                 "*                                                                                              *\n" +


### PR DESCRIPTION
Fixes #623
Maven plugin is completely removed and replaced by the new maven-publish plugin. Creates pom files in respected dist folders. The pom files are copied from build/publications/pub-name/pom-default.xml to the dist directory.
**Usage**

- **Creation of pom-default.xml files at locations:**   
root/core/build/publications/corePublication/pom-default.xml
root/mode/libraries/ar/build/publications/arPublication/pom-default.xml
root/mode/libraries/vr/build/publications/vrPublication/pom-default.xml

- **Commands to generate these files are:**
gradle generatePomFileForcorePublicationPublication
gradle generatePomFileForarPublicationPublication
gradle generatePomFileForvrPublicationPublication

Before executing Gradle build, Either the above commands need to be executed one by one or combined as:
 ```
gradle generatePomFileForcorePublicationPublication generatePomFileForarPublicationPublication generatePomFileForvrPublicationPublication build
```
The error will be handled with the instructions in case if 'gradle build' is executed before the creation of pom files as follows:

![erhandled](https://user-images.githubusercontent.com/46577873/103685474-4cbb0f80-4fb3-11eb-9175-40323f5c92cb.JPG)



