### PR TITLE
fix android mode did not copy 64bits native lib to gradle libs directory

### DIFF
--- a/mode/src/processing/mode/android/AndroidBuild.java
+++ b/mode/src/processing/mode/android/AndroidBuild.java
@@ -792,9 +792,12 @@ class AndroidBuild extends JavaBuild {
           System.err.println(AndroidMode.getTextString("android_build.error.export_file_does_not_exist", exportFile.getName()));
         } else if (exportFile.isDirectory()) {
           // Copy native library folders to the correct location
-          if (exportName.equals("armeabi") ||
+          if (exportName.equals("armeabi")     ||
               exportName.equals("armeabi-v7a") ||
-              exportName.equals("x86")) {
+              exportName.equals("x86")         ||
+              exportName.equals("arm64-v8a")   ||
+              exportName.equals("x86_64")) 
+          {
             Util.copyDir(exportFile, new File(libsFolder, exportName));
           }
           // Copy jni libraries (.so files) to the correct location

--- a/mode/templates/ARBuildECJ.gradle.tmpl
+++ b/mode/templates/ARBuildECJ.gradle.tmpl
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
+    sourceSets 
+    {
+       main.jni.srcDirs = []
+       main.jniLibs.srcDirs = ['libs']
+    }
     compileSdkVersion @@target_sdk@@
     defaultConfig {
         applicationId "@@package_name@@"

--- a/mode/templates/AppBuild.gradle.tmpl
+++ b/mode/templates/AppBuild.gradle.tmpl
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
+    sourceSets 
+    {
+       main.jni.srcDirs = []
+       main.jniLibs.srcDirs = ['libs']
+    }
     compileSdkVersion @@target_sdk@@
     defaultConfig {
         applicationId "@@package_name@@"

--- a/mode/templates/AppBuildECJ.gradle.tmpl
+++ b/mode/templates/AppBuildECJ.gradle.tmpl
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
+    sourceSets 
+    {
+       main.jni.srcDirs = []
+       main.jniLibs.srcDirs = ['libs']
+    }
     compileSdkVersion @@target_sdk@@
     defaultConfig {
         applicationId "@@package_name@@"


### PR DESCRIPTION
When I have a library like below in Processing/libraries, Android mode will not copy 64 bit version of the native lib, `arm64-v8a` and `x86_64` to the gradle libs dir. Those native shared libs are needed on android device with 64 bit kernel.

```

virtualMidiDevice
└── library
    ├── arm64-v8a
    │   └── libmidi.so
    ├── armeabi-v7a
    │   └── libmidi.so
    ├── virtualMidiDevice.jar
    ├── x86
    │   └── libmidi.so
    └── x86_64
        └── libmidi.so

```