### PR TITLE
Permission Selector Text Fix

### DIFF
--- a/mode/languages/mode.properties
+++ b/mode/languages/mode.properties
@@ -245,7 +245,7 @@ manifest.warn.cannot_handle_file_body = Errors occurred while reading or writing
 # Permissions
 
 permissions.dialog.label = <html>Android applications must specifically ask for permission\nto do things like connect to the internet, write a file,\nor make phone calls. When installing your application,\nusers will be asked whether they want to allow such access.</html>
-permissions.dialog.url = "<html>More about permissions can be found <a href=\"%s\">here</a>.</html>
+permissions.dialog.url = <html>More about permissions can be found <a href=\"%s\">here</a>.</html>
 
 # ---------------------------------------
 # SDK Downloader


### PR DESCRIPTION
Fixes #647 

There was an unnecessary double quotes character in the text.
Dialog box  after the fix:

![UrlBugIssueResolvedcrop](https://user-images.githubusercontent.com/46577873/114320849-988ecf00-9b35-11eb-80a1-84b22dd69ecd.png)

