### PR TITLE
AAB(Android App Bundle) Support

### DIFF
--- a/mode/languages/mode.properties
+++ b/mode/languages/mode.properties
@@ -13,6 +13,7 @@
 
 menu.file.export_signed_package = Export Signed Package
 menu.file.export_android_project = Export Android Project
+menu.file.export_signed_bundle = Export Signed Bundle
 
 # | File | Edit | Sketch | Android | Tools | Help |
 #                        | Android |
@@ -61,8 +62,11 @@ android_editor.status.exporting_project = Exporting an Android project of the sk
 android_editor.status.project_export_completed = Done with project export.
 android_editor.status.project_export_failed = Error with project export.
 android_editor.status.exporting_package = Exporting signed package...
+android_editor.status.exporting_bundle = Exporting signed bundle...
 android_editor.status.package_export_completed = Done with package export.
+android_editor.status.bundle_export_completed = Done with bundle export.
 android_editor.status.package_export_failed = Error with package export.
+android_editor.status.bundle_export_failed = Error with bundle export.
 android_editor.error.cannot_create_sketch_properties = Error While creating sketch properties file "%s": %s
 
 # ---------------------------------------
@@ -84,8 +88,10 @@ android_mode.dialog.wallpaper_installed_body = Processing just built and install
 android_mode.dialog.watchface_installed_title = Watch face installed!
 android_mode.dialog.watchface_installed_body = Processing just built and installed your sketch as a watch face on the selected device.<br><br>You need to add it as a favourite watch face on the device and then select it from the watch face picker in order to run it.
 android_mode.dialog.cannot_export_package_title = Cannot export package...
+android_mode.dialog.cannot_export_bundle_title = Cannot export bundle...
 android_mode.dialog.cannot_export_package_body = The sketch still has the default package name. Not good, since this name will uniquely identify your app on the Play store... for ever! Come up with a different package name and write in the AndroidManifest.xml file in the sketch folder, after the "package=" attribute inside the manifest tag, which also contains version code and name. Once you have done that, try exporting the sketch again.<br><br>For more info on distributing apps from Processing,<br>check <a href=\"%s\">this online tutorial</a>.
 android_mode.dialog.cannot_use_default_icons_title = Cannot export package...
+android_mode.dialog.cannot_use_default_icons_title_bundle = Cannot export bundle...
 android_mode.dialog.cannot_use_default_icons_body = The sketch does not include all required app icons. Processing could use its default set of Android icons, which are okay to test the app on your device, but a bad idea to distribute it on the Play store. Create a full set of unique icons for your app, and copy them into the sketch folder. Once you have done that, try exporting the sketch again.<br><br>For more info on distributing apps from Processing,<br>check <a href=\"%s\">this online tutorial</a>.
 android_mode.warn.cannot_load_sdk_title = Bad news...
 android_mode.warn.cannot_load_sdk_body = The Android SDK could not be loaded.\nThe Android Mode will be disabled.

--- a/mode/languages/mode_ko.properties
+++ b/mode/languages/mode_ko.properties
@@ -13,6 +13,7 @@
 
 menu.file.export_signed_package = 서명 된 패키지 내보내기
 menu.file.export_android_project = 안드로이드 프로젝트 내보내기
+menu.file.export_signed_bundle = 안드로이드 번들 내보내기
 
 # | File | Edit | Sketch | Android | Tools | Help |
 #                        | Android |

--- a/mode/src/processing/mode/android/AndroidMode.java
+++ b/mode/src/processing/mode/android/AndroidMode.java
@@ -326,21 +326,26 @@ public class AndroidMode extends JavaMode {
   }
 
   
-  public boolean checkPackageName(Sketch sketch, int comp) {
+  public boolean checkPackageName(Sketch sketch, int comp, boolean forBundle) {
     Manifest manifest = new Manifest(sketch, comp, getFolder(), false);
     String defName = Manifest.BASE_PACKAGE + "." + sketch.getName().toLowerCase();    
     String name = manifest.getPackageName();
     if (name.toLowerCase().equals(defName.toLowerCase())) {
       // The user did not set the package name, show error and stop
-      AndroidUtil.showMessage(AndroidMode.getTextString("android_mode.dialog.cannot_export_package_title"),
-                              AndroidMode.getTextString("android_mode.dialog.cannot_export_package_body", DISTRIBUTING_APPS_TUT_URL));
+      if(forBundle){
+        AndroidUtil.showMessage(AndroidMode.getTextString("android_mode.dialog.cannot_export_bundle_title"),
+                AndroidMode.getTextString("android_mode.dialog.cannot_export_package_body", DISTRIBUTING_APPS_TUT_URL));
+      }else {
+        AndroidUtil.showMessage(AndroidMode.getTextString("android_mode.dialog.cannot_export_package_title"),
+                AndroidMode.getTextString("android_mode.dialog.cannot_export_package_body", DISTRIBUTING_APPS_TUT_URL));
+      }
       return false;
     }
     return true;
   }
   
   
-  public boolean checkAppIcons(Sketch sketch, int comp) {
+  public boolean checkAppIcons(Sketch sketch, int comp, boolean forBundle) {
     File sketchFolder = sketch.getFolder();
 
     File[] launcherIcons = AndroidUtil.getFileList(sketchFolder, AndroidBuild.SKETCH_LAUNCHER_ICONS, 
@@ -355,9 +360,14 @@ public class AndroidMode extends JavaMode {
     
     if (!allFilesExist) {
       // The user did not set custom icons, show error and stop
-      AndroidUtil.showMessage(AndroidMode.getTextString("android_mode.dialog.cannot_use_default_icons_title"),
-                              AndroidMode.getTextString("android_mode.dialog.cannot_use_default_icons_body", DISTRIBUTING_APPS_TUT_URL));
-      return false;      
+      if(forBundle){
+        AndroidUtil.showMessage(AndroidMode.getTextString("android_mode.dialog.cannot_use_default_icons_title_bundle"),
+                AndroidMode.getTextString("android_mode.dialog.cannot_use_default_icons_body", DISTRIBUTING_APPS_TUT_URL));
+      }else {
+        AndroidUtil.showMessage(AndroidMode.getTextString("android_mode.dialog.cannot_use_default_icons_title"),
+                AndroidMode.getTextString("android_mode.dialog.cannot_use_default_icons_body", DISTRIBUTING_APPS_TUT_URL));
+      }
+      return false;
     }
     return true;
   }  
@@ -420,3 +430,4 @@ public class AndroidMode extends JavaMode {
     return String.format(value, arguments);
   }  
 }
+

--- a/mode/src/processing/mode/android/AndroidToolbar.java
+++ b/mode/src/processing/mode/android/AndroidToolbar.java
@@ -46,6 +46,8 @@ public class AndroidToolbar extends EditorToolbar {
   static protected final int OPEN   = 3;
   static protected final int SAVE   = 4;
   static protected final int EXPORT = 5;
+  static protected final int EXPORT_BUNDLE = 6;
+
 
   private AndroidEditor aEditor;
 
@@ -77,6 +79,7 @@ public class AndroidToolbar extends EditorToolbar {
     case SAVE:   return "Save";
     case EXPORT: return !shift ? AndroidMode.getTextString("menu.file.export_signed_package") : 
                                  AndroidMode.getTextString("menu.file.export_android_project");
+    case EXPORT_BUNDLE: return AndroidMode.getTextString("menu.file.export_signed_bundle");
     }
     return null;
   }
@@ -251,3 +254,4 @@ public class AndroidToolbar extends EditorToolbar {
     repaint();
   }
 }
+

--- a/mode/src/processing/mode/android/KeyStoreManager.java
+++ b/mode/src/processing/mode/android/KeyStoreManager.java
@@ -64,14 +64,14 @@ public class KeyStoreManager extends JFrame {
   JTextField country;
   JTextField stateName;
 
-  public KeyStoreManager(final AndroidEditor editor) {
+  public KeyStoreManager(final AndroidEditor editor, boolean forBundle) {
     super("Android keystore manager");
     this.editor = editor;
 
-    createLayout();
+    createLayout(forBundle);
   }
 
-  private void createLayout() {
+  private void createLayout( boolean forBundleExport) {
     Container outer = getContentPane();
     outer.removeAll();
 
@@ -105,13 +105,21 @@ public class KeyStoreManager extends JFrame {
                   localityName.getText(), stateName.getText(), country.getText());
 
               setVisible(false);
-              editor.startExportPackage(new String(passwordField.getPassword()));
+              if(forBundleExport){
+                editor.startExportBundle(new String(passwordField.getPassword()));
+              }else {
+                editor.startExportPackage(new String(passwordField.getPassword()));
+              }
             } catch (Exception e1) {
               e1.printStackTrace();
             }
           } else {
             setVisible(false);
-            editor.startExportPackage(new String(passwordField.getPassword()));
+            if(forBundleExport){
+              editor.startExportBundle(new String(passwordField.getPassword()));
+            }else {
+              editor.startExportPackage(new String(passwordField.getPassword()));
+            }
           }
         }
       }
@@ -147,7 +155,7 @@ public class KeyStoreManager extends JFrame {
             setVisible(true);
           } else {
             keyStore = null;
-            createLayout();
+            createLayout(forBundleExport);
           }
         }
       }

--- a/mode/src/processing/mode/android/Manifest.java
+++ b/mode/src/processing/mode/android/Manifest.java
@@ -48,7 +48,7 @@ public class Manifest {
   static final String MANIFEST_ERROR_MESSAGE =
     "Errors occurred while reading or writing " + MANIFEST_XML + ",\n" +
     "which means lots of things are likely to stop working properly.\n" +
-    "To prevent losing any data, it's recommended that you use Save As\n" +
+    "To prevent losing any data, it's recommended that you use “Save As”\n" +
     "to save a separate copy of your sketch, and then restart Processing.";
   
   static private final String[] MANIFEST_TEMPLATE = {

--- a/mode/src/processing/mode/android/Manifest.java
+++ b/mode/src/processing/mode/android/Manifest.java
@@ -48,7 +48,7 @@ public class Manifest {
   static final String MANIFEST_ERROR_MESSAGE =
     "Errors occurred while reading or writing " + MANIFEST_XML + ",\n" +
     "which means lots of things are likely to stop working properly.\n" +
-    "To prevent losing any data, it's recommended that you use “Save As”\n" +
+    "To prevent losing any data, it's recommended that you use Save As\n" +
     "to save a separate copy of your sketch, and then restart Processing.";
   
   static private final String[] MANIFEST_TEMPLATE = {


### PR DESCRIPTION
Fixes #594 

As AAB is the only way to distribute apps on Google Play Console. This PR adds a feature to generate signed AAB and Unsigned AAB. For Testing purposes, a universal APK was created with the help of bundletool.jar(included in SDK) from generated AAB file and installed on the emulator. No issue has been faced by doing so.

**Generates AAB files as-**
`Documents/Processing/sketch_210923a/buildBundle/sketch_210923a_release_signed.aab`
`Documents/Processing/sketch_210923a/buildBundle/sketch_210923a_release_unsigned.aab`

**Regenerates Bundles similar to export-package utility as -**
`Documents/Processing/sketch_210923a/buildBundle.210924.0527/sketch_210923a_release_signed.aab`
`Documents/Processing/sketch_210923a/buildBundle.210924.0527/sketch_210923a_release_unsigned.aab`

**Method of initiating the task**
     `File -> Export Signed Bundle`

**Keyboard Short Cut**
`Ctrl + B`


![Capture](https://user-images.githubusercontent.com/46577873/134603446-815877df-fcef-42a7-9f6a-c4bfa41da87a.PNG)


