### PR TITLE
Update AndroidBuild.java for AAB Jar Signing(V1 Signature)

### DIFF
--- a/mode/src/processing/mode/android/AndroidBuild.java
+++ b/mode/src/processing/mode/android/AndroidBuild.java
@@ -789,19 +789,27 @@ class AndroidBuild extends JavaBuild {
         keyStore.getAbsolutePath(), keyStorePassword);
 
     if (isAAB) {
-      File signedPackageV2 = new File(projectFolder,
-                                      path + sketch.getName().toLowerCase() + "_release_signed_v2." + fileExt);
-      ApkSignerV2.signJarV2(signedPackageV1, signedPackageV2,
-          AndroidKeyStore.ALIAS_STRING, keyStorePassword, 
-          keyStore.getAbsolutePath(), keyStorePassword);
-      return signedPackageV2;
+      return signedPackageV1;
     } else {
-      File alignedPackage = zipalignPackage(signedPackageV1, projectFolder, fileExt);
+    	
+    	// To Do: The following Currently showing "Error with package export" on V2 signed APK generation
+    	// So for now keeping it as it is and continuing with V1 signing on APKs
+    	
+    	// File signedPackageV2 = new File(projectFolder,
+        //         path + sketch.getName().toLowerCase() + "_release_signed_v2." + fileExt);
+        //         ApkSignerV2.signJarV2(signedPackageV1, signedPackageV2,
+        //         AndroidKeyStore.ALIAS_STRING, keyStorePassword, 
+        //         keyStore.getAbsolutePath(), keyStorePassword);
+        // File alignedPackage = zipalignPackage(signedPackageV2, projectFolder, fileExt, "v2");
+    	
+    	
+    	File alignedPackage = zipalignPackage(signedPackageV1, projectFolder, fileExt, "v1");
+    	
       return alignedPackage;  
     }
   }
   
-  private File zipalignPackage(File signedPackage, File projectFolder, String fileExt)
+  private File zipalignPackage(File signedPackage, File projectFolder, String fileExt, String signingType)
       throws IOException, InterruptedException {
     File zipAlign = sdk.getZipAlignTool();
     if (zipAlign == null || !zipAlign.exists()) {
@@ -811,7 +819,7 @@ class AndroidBuild extends JavaBuild {
     }
     
     File alignedPackage = new File(projectFolder, 
-        getPathToAPK() + sketch.getName().toLowerCase() + "_release_signed_aligned."+fileExt);
+        getPathToAPK() + sketch.getName().toLowerCase() + "_release_signed_aligned"+signingType+"."+fileExt);
 
     String[] args = {
         zipAlign.getAbsolutePath(), "-v", "-f", "4",


### PR DESCRIPTION
Hi @codeanticode @ranaaditya 
I found that just Jar signing (V1 signature Scheme) would be sufficient to build bundles that would be uploadable on Play Console. Not sure as I don't have access to the play console But I tried comparing the signing information of the Jar Signed Bundle generated from this PR and the signed bundle generated from Android Studio. I found that both the bundles are signed with the same signing algorithm.

```
Android Mode Generated Bundle's Signing Information

C:\Users\xyz> keytool -printcert -jarfile C:\Users\xyz\Documents\Processing\sketch_220405a\buildBundle.220405.1115\sketch_220405a_release_signed_v1.aab
Signer #1:
Signature:
Certificate fingerprints:
         SHA1: 24:E4:***
         SHA256: 05:30:***
Signature algorithm name: SHA256withRSA
Subject Public Key Algorithm: 2048-bit RSA key
Version: 3
```

```
Android Studio Generated Bundle's Signing Information

Signer #1:
Signature:
Certificate fingerprints:
         SHA1: DA:08:***
         SHA256: 2D:A9:***
Signature algorithm name: SHA256withRSA
Subject Public Key Algorithm: 2048-bit RSA key
Version: 3
```

I thought of signing aab with bundletool but it's not included in SDK and the size of bundletool-all.jar is around 26 mb where as AndroidMode itself is around 13 MB. Later found that Jar Signing(V1 signature scheme) would be sufficient. 

Can you confirm if the generated signed bundle is uploadable on Play Console? @codeanticode 

Thanks,
Rupesh

