### PR TITLE
Resolves 'gradlew dist' Errors on execution of command consecutively

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,16 +58,29 @@ compileJava.doFirst {
 }
 
 build.doLast {
-    // Copying core jar as zip inside the mode folder
-    Files.copy(file("${buildDir}/libs/core.jar").toPath(),
+
+    // Need to check the existance of the files before using as the files 
+    // will get generated only if  Task :core:jar is not being skipped
+    // Task :core:jar will be skipped if source files are unchanged or jar task is UP-TO-DATE
+    
+    if(file("${buildDir}/libs/core.jar").exists()){
+        // Copying core jar as zip inside the mode folder
+        Files.copy(file("${buildDir}/libs/core.jar").toPath(), 
             file("${coreZipPath}").toPath(), REPLACE_EXISTING)
+    }
     // Renaming artifacts for maven publishing
-    Files.move(file("${buildDir}/libs/core.jar").toPath(),
-               file("$buildDir/libs/processing-core-${modeVersion}.jar").toPath(), REPLACE_EXISTING);
-    Files.move(file("${buildDir}/libs/core-sources.jar").toPath(),
-               file("$buildDir/libs/processing-core-${modeVersion}-sources.jar").toPath(), REPLACE_EXISTING);
-    Files.move(file("${buildDir}/libs/core.jar.MD5").toPath(),
-               file("$buildDir/libs/processing-core-${modeVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    if(file("${buildDir}/libs/core.jar").exists()){
+        Files.move(file("${buildDir}/libs/core.jar").toPath(),
+            file("$buildDir/libs/processing-core-${modeVersion}.jar").toPath(), REPLACE_EXISTING);
+    }
+    if(file("${buildDir}/libs/core-sources.jar").exists()){
+        Files.move(file("${buildDir}/libs/core-sources.jar").toPath(),
+            file("$buildDir/libs/processing-core-${modeVersion}-sources.jar").toPath(), REPLACE_EXISTING);
+    }
+    if(file("${buildDir}/libs/core.jar.MD5").exists()){
+        Files.move(file("${buildDir}/libs/core.jar.MD5").toPath(),
+            file("$buildDir/libs/processing-core-${modeVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    }
 }
 
 ext {

--- a/mode/libraries/ar/build.gradle
+++ b/mode/libraries/ar/build.gradle
@@ -61,15 +61,28 @@ build.doLast {
     // Copying ar jar to library folder
     File arJar = file("library/ar.jar")
     arJar.mkdirs();
-    Files.copy(file("$buildDir/libs/ar.jar").toPath(),
-               arJar.toPath(), REPLACE_EXISTING);
+    
+    // Need to check the existance of the files before using as the files 
+    // will get generated only if Task ':mode:libraries:ar:jar' is not being skipped
+    // Task ':mode:libraries:ar:jar' will be skipped if source files are unchanged or jar task is UP-TO-DATE
+    
+    if(file("$buildDir/libs/ar.jar").exists()){
+        Files.copy(file("$buildDir/libs/ar.jar").toPath(),
+                   arJar.toPath(), REPLACE_EXISTING);
+    }
     // Renaming artifacts for maven publishing
-    Files.move(file("$buildDir/libs/ar.jar").toPath(),
-               file("$buildDir/libs/processing-ar-${arLibVersion}.jar").toPath(), REPLACE_EXISTING);
-    Files.move(file("$buildDir/libs/ar-sources.jar").toPath(),
-               file("$buildDir/libs/processing-ar-${arLibVersion}-sources.jar").toPath(), REPLACE_EXISTING);
-    Files.move(file("$buildDir/libs/ar.jar.MD5").toPath(),
-               file("$buildDir/libs/processing-ar-${arLibVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    if(file("$buildDir/libs/ar.jar").exists()){
+        Files.move(file("$buildDir/libs/ar.jar").toPath(),
+                   file("$buildDir/libs/processing-ar-${arLibVersion}.jar").toPath(), REPLACE_EXISTING);
+    }
+    if(file("$buildDir/libs/ar-sources.jar").exists()){
+        Files.move(file("$buildDir/libs/ar-sources.jar").toPath(),
+                   file("$buildDir/libs/processing-ar-${arLibVersion}-sources.jar").toPath(), REPLACE_EXISTING);
+    }
+    if(file("$buildDir/libs/ar.jar.MD5").exists()){
+        Files.move(file("$buildDir/libs/ar.jar.MD5").toPath(),
+                   file("$buildDir/libs/processing-ar-${arLibVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    }
 }
 
 ext {

--- a/mode/libraries/vr/build.gradle
+++ b/mode/libraries/vr/build.gradle
@@ -61,15 +61,28 @@ build.doLast {
     // Copying vr jar to library folder
     File vrJar = file("library/vr.jar")
     vrJar.mkdirs();
-    Files.copy(file("$buildDir/libs/vr.jar").toPath(),
-               vrJar.toPath(), REPLACE_EXISTING);
+    
+    // Need to check the existance of the files before using as the files 
+    // will get generated only if Task ':mode:libraries:vr:jar' is not being skipped
+    // Task ':mode:libraries:vr:jar' will be skipped if source files are unchanged or jar task is UP-TO-DATE
+    
+    if(file("$buildDir/libs/vr.jar").exists()){
+        Files.copy(file("$buildDir/libs/vr.jar").toPath(),
+                   vrJar.toPath(), REPLACE_EXISTING);
+    }
     // Renaming artifacts for maven publishing
-    Files.move(file("$buildDir/libs/vr.jar").toPath(),
-               file("$buildDir/libs/processing-vr-${vrLibVersion}.jar").toPath(), REPLACE_EXISTING);
-    Files.move(file("$buildDir/libs/vr-sources.jar").toPath(),
-               file("$buildDir/libs/processing-vr-${vrLibVersion}-sources.jar").toPath(), REPLACE_EXISTING);
-    Files.move(file("$buildDir/libs/vr.jar.MD5").toPath(),
-               file("$buildDir/libs/processing-vr-${vrLibVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    if(file("$buildDir/libs/vr.jar").exists()){
+        Files.move(file("$buildDir/libs/vr.jar").toPath(),
+                   file("$buildDir/libs/processing-vr-${vrLibVersion}.jar").toPath(), REPLACE_EXISTING);
+    }
+    if(file("$buildDir/libs/vr-sources.jar").exists()){
+        Files.move(file("$buildDir/libs/vr-sources.jar").toPath(),
+                   file("$buildDir/libs/processing-vr-${vrLibVersion}-sources.jar").toPath(), REPLACE_EXISTING);
+    }
+    if(file("$buildDir/libs/vr.jar.MD5").exists()){
+        Files.move(file("$buildDir/libs/vr.jar.MD5").toPath(),
+                   file("$buildDir/libs/processing-vr-${vrLibVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+    }
 }
 
 ext {


### PR DESCRIPTION
Fixes #687  

Resolves both `gradlew dist` and `gradlew build` Errors on executing the command one by one. 

**Why the issue arises?**
Because core.jar, vr.jar, etc. files are not getting generated because the Jar tasks are getting skipped. The reason for skipping of jar task is because it is UP-TO-DATE or the source files are not getting changed. This can be identified by `gradlew dist -info` which says the Jar task is skipped(while executing the command again without modifying the source files)

When executing `gradlew dist -info` for the first time it shows the following-
```
> Task :core:jar
Caching disabled for task ':core:jar' because:
  Build cache is disabled
Task ':core:jar' is not up-to-date because:
  Output property 'archiveFile' file *\processing-android-android-0402-v4.5.0a3\core\build\libs\core.jar 
has been removed.
*\processing-android-android-0402-v4.5.0a3\core\build\libs\core.jar
(Thread[Execution worker for ':',5,main]) completed. Took 0.396 secs.
:core:sourceJar (Thread[Execution worker for ':',5,main]) started.
```

Executing the same command for the second time without changing the source files shows the following-
```
> Task :core:jar UP-TO-DATE
Caching disabled for task ':core:jar' because:
  Build cache is disabled
Skipping task ':core:jar' as it is up-to-date.
:core:jar (Thread[Execution worker for ':',5,main]) completed. Took 0.001 secs.
:core:sourceJar (Thread[Execution worker for ':',5,main]) started.
```
This issue is the same for the libraries AR and VR.

**Solution with this PR**
This PR applies 'if conditions' to check the existence of necessary files i.e core.jar, vr.jar, etc. Do the copy/move operations if files exist otherwise no need to copy or move the files as we know the files do not exist and `processing-core.jar`, `ar.jar`, etc. are already `UP-TO-DATE`(jar task get skipped in this case).
