### PR TITLE
Working Debugger with Variable Inspector - Final PR

### DIFF
--- a/mode/src/processing/mode/android/AndroidDebugger.java
+++ b/mode/src/processing/mode/android/AndroidDebugger.java
@@ -88,6 +88,9 @@ public class AndroidDebugger extends Debugger {
 
     inspector.reset();
 
+    // make the inspector instance visible on which tree nodes would be reflected
+    inspector.setVisible(true);
+
     runtime = runner;
     pkgName = runner.build.getPackageName();
     sketchClassName = runner.build.getSketchClassName();

--- a/mode/src/processing/mode/android/AndroidEditor.java
+++ b/mode/src/processing/mode/android/AndroidEditor.java
@@ -485,6 +485,8 @@ public class AndroidEditor extends JavaEditor {
   @Override
   public void toggleDebug() {
     super.toggleDebug();
+    // make the unused inspector invisible
+    super.debugger.dispose();
     debugger.toggleDebug();
   }
 

--- a/mode/src/processing/mode/android/AndroidToolbar.java
+++ b/mode/src/processing/mode/android/AndroidToolbar.java
@@ -82,8 +82,8 @@ public class AndroidToolbar extends EditorToolbar {
   @Override
   public List<EditorButton> createButtons() {
     // aEditor not ready yet because this is called by super()
-//    final boolean debug = ((AndroidEditor) editor).isDebuggerEnabled();
-    final boolean debug = false;
+    final boolean debug = ((AndroidEditor) editor).isDebuggerEnabled();
+    // final boolean debug = false;
     
 
     ArrayList<EditorButton> toReturn = new ArrayList<EditorButton>();
@@ -150,7 +150,7 @@ public class AndroidToolbar extends EditorToolbar {
   
   @Override
   public void addModeButtons(Box box, JLabel label) {
-    /*
+
     EditorButton debugButton =
             new EditorButton(this, "/lib/toolbar/debug",
                     Language.text("toolbar.debug")) {
@@ -166,7 +166,7 @@ public class AndroidToolbar extends EditorToolbar {
 //    debugButton.setRolloverLabel(label);
     box.add(debugButton);
     addGap(box);
-    */
+
   }
 
   @Override
@@ -216,4 +216,3 @@ public class AndroidToolbar extends EditorToolbar {
     repaint();
   }
 }
-


### PR DESCRIPTION
This PR is the further improvements on the leftover functionalities from the previous PR #710 

This PR provides-

- Working Android Debugger
- Working Variable Inspector
- Working Buttons for operating the Debugger(on the Toolbar and inside the Menu Bar).

![DebuggerAndVariableInspector](https://user-images.githubusercontent.com/46577873/192116275-edc92c9a-9258-42f5-8d78-30eac1611631.PNG)
(Note: I am using a mirror software while running the sketch on the actual device(not the emulator) shown in the screenshot above)


I missed adding [this line](https://github.com/rupeshkumar22/processing-android/blob/3d758b3a3d5fe9a9e937c87f551ce438cd87b1c0/mode/src/processing/mode/android/AndroidToolbar.java#L85) in the previous PR because of which the debugger might not work in the last beta release. But a new beta release after merging this PR would resolve the debugger issue @codeanticode 

As per the recent discussions with @ranaaditya , We may think of redesigning the current implementation of the debugger in the future, to make the implementation more simplified. But for now as the debugger is working fine, I am moving further to other tasks.


An outcome of Google Summer of Code 2022
Author - Rupesh Kumar @rupeshkumar22
Mentor - Aditya Rana @ranaaditya
Project Lead(Processing For Android) - Andrés Colubri @codeanticode
