### PR TITLE
Update LoadDisplayImage.pde

### DIFF
--- a/mode/examples/Basics/Image/LoadDisplayImage/LoadDisplayImage.pde
+++ b/mode/examples/Basics/Image/LoadDisplayImage/LoadDisplayImage.pde
@@ -12,7 +12,6 @@ void setup() {
   // The file "jelly.jpg" must be in the data folder
   // of the current sketch to load successfully
   a = loadImage("jelly.jpg");  // Load the image into the program  
-  noLoop();  // Makes draw() only run once
 }
 
 void draw() {


### PR DESCRIPTION
A very simple correction in a basic example.

delete noLoop(). 

The image was not seeing in some devices.