### PR TITLE
Incorporating New Reference Setup - Bug Fix #746

### DIFF
--- a/mode/src/processing/mode/android/AndroidEditor.java
+++ b/mode/src/processing/mode/android/AndroidEditor.java
@@ -367,10 +367,9 @@ public class AndroidEditor extends JavaEditor {
 
 
   /** override the standard grab reference to just show the java reference */
+  @Override
   public void showReference(String filename) {
-    File javaReferenceFolder = Platform.getContentFile("modes/java/reference");
-    File file = new File(javaReferenceFolder, filename);
-    Platform.openURL(file.toURI().toString());
+    super.showReference(filename);
   }
   
   


### PR DESCRIPTION
Fixes #746 


![Capture](https://github.com/processing/processing-android/assets/46577873/5e173476-e4be-4738-8546-eb7850aaac77)


**Steps to Reproduce**

> Open Processing
> Help > Environment or Reference
> See Console for the error log

As mentioned by @benfry  on #746 we require latest reference setup, I believe inheriting the methods from base classes will provide the new functionality.

Changes are working fine on Windows. Both Environment Page and Reference Page are opeing up. No issues are expected on other systems as we are inheriting the existing functionality into Android Mode.




