### PR TITLE
fixed Android Mode 4.6 Installation Issue

### DIFF
--- a/processing/mode/src/processing/mode/android/AndroidSDK.java
+++ b/processing/mode/src/processing/mode/android/AndroidSDK.java
@@ -405,10 +405,19 @@ class AndroidSDK {
    */
   private static File findCliTool(final File toolDir, String toolName)
       throws BadSDKException {
-    File toolFile = Platform.isWindows() ? new File(toolDir, toolName + ".exe") : new File(toolDir, toolName);
-    if (!toolFile.exists()) {
-      throw new BadSDKException("Cannot find " + toolName + " in " + toolDir);
-    }
+        File toolFile;
+        if (Platform.isWindows()) {
+            toolFile = new File(toolDir, toolName + ".exe");
+            if (!toolFile.exists()) {
+                toolFile = new File(toolDir, toolName + ".bat");
+            }
+        } else {
+            toolFile = new File(toolDir, toolName);
+        }
+        
+        if (!toolFile.exists()) {
+            throw new BadSDKException("Cannot find " + toolName + " in " + toolDir);
+        }
 
     if (!Platform.isWindows()) {
       try {


### PR DESCRIPTION
Closes https://github.com/processing/processing-android/issues/768

The failure to consider .bat files is the root cause of this issue, which is also triggering a secondary problem: the "Bad news.." error. Despite downloading or selecting the correct SDK package, the error persists. Fortunately, the issue was resolved by incorporating .bat files into the code.
