### PR TITLE
Fix Particles demos

### DIFF
--- a/processing/mode/examples/Demos/Graphics/Particles/Particles.pde
+++ b/processing/mode/examples/Demos/Graphics/Particles/Particles.pde
@@ -3,8 +3,11 @@
 ParticleSystem ps;
 PImage sprite;  
 
-void setup() {
+void settings() {
   size(displayWidth, displayHeight, P2D);
+}
+
+void setup() {
   orientation(LANDSCAPE);
   sprite = loadImage("sprite.png");
   ps = new ParticleSystem(2000);


### PR DESCRIPTION
As per https://github.com/processing/processing-docs/issues/298#issuecomment-140218268, `size()` must be called within `settings` when using variables. This change was required to get the demo to run.